### PR TITLE
Add DateTIme.Add(Duration) and DateTimeOffset.Add(Duration)

### DIFF
--- a/src/Iso8601DurationHelper/Duration.cs
+++ b/src/Iso8601DurationHelper/Duration.cs
@@ -678,4 +678,32 @@ namespace Iso8601DurationHelper
             Seconds = Minutes + 1
         }
     }
+
+    /// <summary>
+    /// Extension class to add functionality to <see cref="DateTime"/> and <see cref="DateTimeOffset"/>
+    /// </summary>
+    public static class DateTimeHelper 
+    {
+        /// <summary>
+		  /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/> instant
+		  /// </summary>
+		  /// <param name="date">The date to add to</param>
+		  /// <param name="duration">The duration to add</param>
+		  /// <returns></returns>
+        public static DateTime Add(this DateTime date, Duration duration)
+        {
+            return date + duration;
+        }
+
+        /// <summary>
+        /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/> instant
+        /// </summary>
+        /// <param name="date">The date to add to</param>
+        /// <param name="duration">The duration to add</param>
+        /// <returns></returns>
+        public static DateTimeOffset Add(this DateTimeOffset date, Duration duration)
+        {
+            return date + duration;
+        }
+    }
 }

--- a/src/Iso8601DurationHelper/Duration.cs
+++ b/src/Iso8601DurationHelper/Duration.cs
@@ -682,25 +682,25 @@ namespace Iso8601DurationHelper
     /// <summary>
     /// Extension class to add functionality to <see cref="DateTime"/> and <see cref="DateTimeOffset"/> so that use of <see cref="Duration"/> is similar to using <see cref="TimeSpan"/>
     /// </summary>
-    public static class DateTimeHelper 
+    public static class DateTimeDurationExtensions 
     {
         /// <summary>
-        /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/> instant
+        /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/>
         /// </summary>
         /// <param name="date">The date to add to</param>
         /// <param name="duration">The duration to add</param>
-        /// <returns></returns>
+        /// <returns>An object whose value is the sum of the date and time represented by this instance and the interval represented by duration.</returns>
         public static DateTime Add(this DateTime date, Duration duration)
         {
             return date + duration;
         }
 
         /// <summary>
-        /// Adds a <see cref="Duration"/> value to a <see cref="DateTimeOffset"/> instant
+        /// Adds a <see cref="Duration"/> value to a <see cref="DateTimeOffset"/>
         /// </summary>
         /// <param name="date">The date to add to</param>
         /// <param name="duration">The duration to add</param>
-        /// <returns></returns>
+        /// <returns>An object whose value is the sum of the date and time represented by this instance and the interval represented by duration.</returns>
         public static DateTimeOffset Add(this DateTimeOffset date, Duration duration)
         {
             return date + duration;

--- a/src/Iso8601DurationHelper/Duration.cs
+++ b/src/Iso8601DurationHelper/Duration.cs
@@ -680,23 +680,23 @@ namespace Iso8601DurationHelper
     }
 
     /// <summary>
-    /// Extension class to add functionality to <see cref="DateTime"/> and <see cref="DateTimeOffset"/>
+    /// Extension class to add functionality to <see cref="DateTime"/> and <see cref="DateTimeOffset"/> so that use of <see cref="Duration"/> is similar to using <see cref="TimeSpan"/>
     /// </summary>
     public static class DateTimeHelper 
     {
         /// <summary>
-		  /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/> instant
-		  /// </summary>
-		  /// <param name="date">The date to add to</param>
-		  /// <param name="duration">The duration to add</param>
-		  /// <returns></returns>
+        /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/> instant
+        /// </summary>
+        /// <param name="date">The date to add to</param>
+        /// <param name="duration">The duration to add</param>
+        /// <returns></returns>
         public static DateTime Add(this DateTime date, Duration duration)
         {
             return date + duration;
         }
 
         /// <summary>
-        /// Adds a <see cref="Duration"/> value to a <see cref="DateTime"/> instant
+        /// Adds a <see cref="Duration"/> value to a <see cref="DateTimeOffset"/> instant
         /// </summary>
         /// <param name="date">The date to add to</param>
         /// <param name="duration">The duration to add</param>


### PR DESCRIPTION
Added extension class with two methods, Add(Duration), to DateTime and DateTimeOffset.  These match functionality which already exists in those classes when adjusting a moment in time by a TimeSpan.